### PR TITLE
题目查询有关的三个接口的实现，并根据前端需求修改了题目添加接口

### DIFF
--- a/backend/src/main/java/com/example/petbackend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/petbackend/config/SecurityConfig.java
@@ -41,7 +41,6 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationManager authManager() {
-
         var authProvider = new DaoAuthenticationProvider();
         authProvider.setUserDetailsService(userDetailsService);
         authProvider.setPasswordEncoder(passwordEncoder());
@@ -55,7 +54,7 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/user/login","/api/cate/get_all" , "/api/user/register").permitAll()
+                        .requestMatchers("/api/user/login", "/api/user/register").permitAll()
                          // 微服务配置
                         // .requestMatchers("").hasIpAddress("127.0.0.1")
                         .requestMatchers(HttpMethod.OPTIONS).permitAll()

--- a/backend/src/main/java/com/example/petbackend/controller/medicine/MedicineController.java
+++ b/backend/src/main/java/com/example/petbackend/controller/medicine/MedicineController.java
@@ -16,8 +16,8 @@ public class MedicineController {
 
     /**
      * 添加一个药品
-     * @param map//medicine_name medicine_cost
-     * @return map//error_message medicine_id
+     * @param map//"medicine_name","medicine_cost"
+     * @return map//"error_message","medicine_id"
      */
     @PostMapping("/medications/add")
     public Map<String, String> addMedicine(@RequestParam Map<String, String> map){
@@ -28,8 +28,8 @@ public class MedicineController {
 
     /**
      * 修改一个药品费用
-     * @param map//medicine_id medicine_cost
-     * @return map//error_message
+     * @param map//"medicine_id", "medicine_cost"
+     * @return map//"error_message"
      */
     @PostMapping("/medications/update")
     public Map<String, String> updateMedicine(@RequestParam Map<String, String> map){
@@ -40,8 +40,8 @@ public class MedicineController {
 
     /**
      * 删除一个药品
-     * @param map//medicine_id
-     * @return map//error_message
+     * @param map//"medicine_id"
+     * @return map//"error_message"
      */
     @DeleteMapping("/medications/delete")
     public Map<String, String> deleteMedicine(@RequestParam Map<String, String> map){
@@ -51,8 +51,8 @@ public class MedicineController {
 
     /**
      * 带搜索的分页获取药品列表
-     * @param map//page pageSize key
-     * @return map//error_message medicine_list
+     * @param map//"page pageSize key"
+     * @return map//"error_message" "medicine_list"
      */
     @GetMapping("/medications/getall")
     public Map<String, Object> getAllMedicine(@RequestParam Map<String, String> map){

--- a/backend/src/main/java/com/example/petbackend/controller/question/GetQuestionsController.java
+++ b/backend/src/main/java/com/example/petbackend/controller/question/GetQuestionsController.java
@@ -17,15 +17,41 @@ public class GetQuestionsController {
     private GetQuestionsService getQuestionsService;
 
     /**
-     * 带搜索值分页获取题目列表
+     * 按照题目搜索分页返回题目列表
      * @param map
      * @return
      */
-    @GetMapping("/getAllQuestion")
-    public Map<String, Object> getAllQuestion(@RequestParam Map<String, String> map){
+    @GetMapping("/getAllQuestionByDescription")
+    public Map<String, Object> getAllQuestionByDescription(@RequestParam Map<String, String> map){
         Integer page = Integer.valueOf(map.get("page"));
         Integer pageSize = Integer.valueOf(map.get("pageSize"));
         String key = map.get("key");
-        return getQuestionsService.getAllQuestion(page, pageSize, key);
+        return getQuestionsService.getAllQuestionByDescription(page, pageSize, key);
     }
+
+    /**
+     * 按照病名搜索分页返回题目列表
+     * @param map
+     * @return
+     */
+    @GetMapping("/getAllQuestionByIll")
+    public Map<String, Object> getAllQuestionByIll(@RequestParam Map<String, String> map){
+        Integer page = Integer.valueOf(map.get("page"));
+        Integer pageSize = Integer.valueOf(map.get("pageSize"));
+        String key = map.get("key");
+        return getQuestionsService.getAllQuestionByIll(page,pageSize,key);
+    }
+
+    /**
+     * 按照qid返回题目详情
+     * @param map
+     * @return
+     */
+    @GetMapping("/getQuestionByQid")
+    public Map<String, Object> getQuestionByQid(@RequestParam Map<String, String> map){
+        Integer qid = Integer.valueOf(map.get("qid"));
+        return getQuestionsService.getQuestionByQid(qid);
+    }
+
+
 }

--- a/backend/src/main/java/com/example/petbackend/controller/question/QuestionController.java
+++ b/backend/src/main/java/com/example/petbackend/controller/question/QuestionController.java
@@ -1,7 +1,5 @@
 package com.example.petbackend.controller.question;
 
-
-import com.example.petbackend.service.question.GetQuestionsService;
 import com.example.petbackend.service.question.QuestionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -21,7 +19,7 @@ public class QuestionController {
      * @return
      */
     @PostMapping("/createQuestion")
-    public Map<String, String> addQuestion(@RequestParam Map<String, String> map){
+    public Map<String, Object> addQuestion(@RequestParam Map<String, String> map){
         Integer cate_id = Integer.valueOf(map.get("cate_id"));
         Integer ill_id = Integer.valueOf(map.get("ill_id"));
         String description = map.get("description");

--- a/backend/src/main/java/com/example/petbackend/dto/QuestionDTO.java
+++ b/backend/src/main/java/com/example/petbackend/dto/QuestionDTO.java
@@ -1,0 +1,23 @@
+package com.example.petbackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionDTO {
+    private int qid;
+    private Integer cateID;
+    private String cateName;
+    private Integer illId;
+    private String illName;
+    private String description;
+    private Integer answer;
+    private Integer mark;
+    private String contentA;
+    private String contentB;
+    private String contentC;
+    private String contentD;
+}

--- a/backend/src/main/java/com/example/petbackend/mapper/IllMapper.java
+++ b/backend/src/main/java/com/example/petbackend/mapper/IllMapper.java
@@ -1,0 +1,9 @@
+package com.example.petbackend.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.example.petbackend.pojo.Ill;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface IllMapper extends BaseMapper<Ill> {
+}

--- a/backend/src/main/java/com/example/petbackend/pojo/Ill.java
+++ b/backend/src/main/java/com/example/petbackend/pojo/Ill.java
@@ -1,0 +1,18 @@
+package com.example.petbackend.pojo;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Ill {
+    @TableId(type = IdType.AUTO)
+    private Integer illId;
+    private Integer cateId;
+    private String illName;
+
+}

--- a/backend/src/main/java/com/example/petbackend/service/impl/medicine/MedicineServiceImpl.java
+++ b/backend/src/main/java/com/example/petbackend/service/impl/medicine/MedicineServiceImpl.java
@@ -29,7 +29,7 @@ public class MedicineServiceImpl implements MedicineService {
         medicineMap.put("error_message", "success");
         medicineMap.put("medicine_id", String.valueOf(medicine.getMedicineId()));
         return medicineMap;
-    };
+    }
 
     //修改药品费用
     @Override
@@ -49,7 +49,7 @@ public class MedicineServiceImpl implements MedicineService {
         }
         medicineMap.put("error_message", msg);
         return medicineMap;
-    };
+    }
 
     //删除药品
     @Override
@@ -63,7 +63,7 @@ public class MedicineServiceImpl implements MedicineService {
             medicineMap.put("error_message", "success");
         }
         return medicineMap;
-    };
+    }
 
 
     //带搜索值分页获取药品列表
@@ -79,7 +79,7 @@ public class MedicineServiceImpl implements MedicineService {
             medicineMap.put("error_message", "success");
             medicineMap.put("medicine_list", medicineList);
         } else{
-            medicineMap.put("error_message", "获取失败");
+            medicineMap.put("error_message", "未找到对应药品");
         }
         JSONObject obj = new JSONObject(medicineMap);
         return obj;

--- a/backend/src/main/java/com/example/petbackend/service/impl/question/GetQuestionsServiceImpl.java
+++ b/backend/src/main/java/com/example/petbackend/service/impl/question/GetQuestionsServiceImpl.java
@@ -3,13 +3,20 @@ package com.example.petbackend.service.impl.question;
 import com.alibaba.fastjson.JSONObject;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.example.petbackend.dto.QuestionDTO;
+import com.example.petbackend.mapper.CateMapper;
+import com.example.petbackend.mapper.IllMapper;
 import com.example.petbackend.mapper.QuestionMapper;
+import com.example.petbackend.pojo.Cate;
+import com.example.petbackend.pojo.Ill;
 import com.example.petbackend.pojo.Question;
 import com.example.petbackend.service.question.GetQuestionsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,21 +26,100 @@ public class GetQuestionsServiceImpl implements GetQuestionsService {
 
     @Autowired
     QuestionMapper questionMapper;
-    //带搜索值的分页获取题目列表
-    public Map<String, Object> getAllQuestion(Integer page, Integer pageSize, String key){
+    @Autowired
+    CateMapper cateMapper;
+    @Autowired
+    IllMapper illMapper;
+    //按照题目搜索分页返回题目列表
+    public Map<String, Object> getAllQuestionByDescription(Integer page, Integer pageSize, String key){
+        List<QuestionDTO> questionDTOList = new ArrayList<>();
         IPage<Question> questionPage = new Page<>(page, pageSize);
         QueryWrapper<Question> questionQueryWrapper = new QueryWrapper<>();
         questionQueryWrapper.like("description", key);
         questionPage = questionMapper.selectPage(questionPage, questionQueryWrapper);
         List<Question> questionList = questionPage.getRecords();
+        for(Question question: questionList){
+            Cate cate = cateMapper.selectById(question.getCateId());
+            Ill ill = illMapper.selectById(question.getIllId());
+            QuestionDTO questionDTO = new QuestionDTO();
+            questionDTO.setQid(question.getQid());
+            questionDTO.setCateID(question.getCateId());
+            questionDTO.setCateName(cate.getCateName());
+            questionDTO.setIllId(question.getIllId());
+            questionDTO.setIllName(ill.getIllName());
+            questionDTO.setDescription((question.getDescription()));
+            questionDTO.setMark(question.getMark());
+            questionDTO.setAnswer((question.getAnswer()));
+            questionDTO.setContentA(question.getContentA());
+            questionDTO.setContentB(question.getContentB());
+            questionDTO.setContentC(question.getContentC());
+            questionDTO.setContentD(question.getContentD());
+            questionDTOList.add(questionDTO);
+        }
         Map<String, Object> questionMap = new HashMap<>();
-        if(questionList != null && !questionList.isEmpty()){ //搜到的题目列表不为空
+        if(questionDTOList != null && !questionDTOList.isEmpty()){ //搜到的题目列表不为空
             questionMap.put("error_message", "success");
-            questionMap.put("question_list", questionList);
+            questionMap.put("question_list", questionDTOList);
         } else{
-            questionMap.put("error_message", "获取失败");
+            questionMap.put("error_message", "未找到对应题目");
         }
         JSONObject obj = new JSONObject(questionMap);
         return obj;
+    }
+
+    //按照病名搜索分页返回题目列表
+    public Map<String, Object> getAllQuestionByIll(Integer page, Integer pageSize, String key){
+        QueryWrapper<Ill> illQueryWrapper = new QueryWrapper<>();
+        illQueryWrapper.like("ill_name", key);
+        List<Ill> illList = illMapper.selectList(illQueryWrapper);
+        List<Integer> illIdList = new ArrayList<>();
+        for (Ill ill : illList) {
+            illIdList.add(ill.getIllId());
+        }
+        IPage<Question> questionPage = new Page<>(page, pageSize);
+        questionPage = questionMapper.selectPage(questionPage, Wrappers.<Question>lambdaQuery()
+                .in(Question::getIllId, illIdList));
+        List<Question> questionList = questionPage.getRecords();
+        List<QuestionDTO> questionDTOList = new ArrayList<>();
+        for(Question question: questionList){
+            Cate cate = cateMapper.selectById(question.getCateId());
+            Ill ill = illMapper.selectById(question.getIllId());
+            QuestionDTO questionDTO = new QuestionDTO();
+            questionDTO.setQid(question.getQid());
+            questionDTO.setCateID(question.getCateId());
+            questionDTO.setCateName(cate.getCateName());
+            questionDTO.setIllId(question.getIllId());
+            questionDTO.setIllName(ill.getIllName());
+            questionDTO.setDescription((question.getDescription()));
+            questionDTO.setMark(question.getMark());
+            questionDTO.setAnswer(question.getAnswer());
+            questionDTO.setContentA(question.getContentA());
+            questionDTO.setContentB(question.getContentB());
+            questionDTO.setContentC(question.getContentC());
+            questionDTO.setContentD(question.getContentD());
+            questionDTOList.add(questionDTO);
+        }
+        Map<String, Object> questionMap = new HashMap<>();
+        if(questionDTOList != null && !questionDTOList.isEmpty()){ //搜到的题目列表不为空
+            questionMap.put("error_message", "success");
+            questionMap.put("question_list", questionDTOList);
+        } else{
+            questionMap.put("error_message", "未找到对应题目");
+        }
+        JSONObject obj = new JSONObject(questionMap);
+        return obj;
+    }
+
+    //按照qid返回题目详情
+    public Map<String, Object> getQuestionByQid(Integer qid) {
+        Question question = questionMapper.selectById(qid);
+        Map<String, Object> questionMap = new HashMap<>();
+        if (question != null) {
+            questionMap.put("error_message", "success");
+            questionMap.put("question", question);
+        } else {
+            questionMap.put("error_message", "查看详情失败");
+        }
+        return questionMap;
     }
 }

--- a/backend/src/main/java/com/example/petbackend/service/impl/question/QuestionServiceImpl.java
+++ b/backend/src/main/java/com/example/petbackend/service/impl/question/QuestionServiceImpl.java
@@ -1,10 +1,11 @@
 package com.example.petbackend.service.impl.question;
 
-import com.alibaba.fastjson.JSONObject;
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
-import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.example.petbackend.dto.QuestionDTO;
+import com.example.petbackend.mapper.CateMapper;
+import com.example.petbackend.mapper.IllMapper;
 import com.example.petbackend.mapper.QuestionMapper;
+import com.example.petbackend.pojo.Cate;
+import com.example.petbackend.pojo.Ill;
 import com.example.petbackend.pojo.Question;
 import com.example.petbackend.service.question.QuestionService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,18 +21,37 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Autowired
     QuestionMapper questionMapper;
+    @Autowired
+    CateMapper cateMapper;
+    @Autowired
+    IllMapper illMapper;
 
     //添加题目
     @Override
-    public Map<String, String> addQuestion(Integer cate_id, Integer ill_id, String description,
+    public Map<String, Object> addQuestion(Integer cate_id, Integer ill_id, String description,
                                            Integer answer, Integer mark, String content_a,
                                            String content_b, String content_c, String content_d){
         Question question = new Question(cate_id, ill_id, description, answer, mark,
                                          content_a, content_b, content_c, content_d);
         questionMapper.insert(question);
-        Map<String, String> questionMap = new HashMap<>();
+        Cate cate = cateMapper.selectById(cate_id);
+        Ill ill = illMapper.selectById(ill_id);
+        QuestionDTO questionDTO = new QuestionDTO();
+        questionDTO.setQid(question.getQid());
+        questionDTO.setCateID(cate_id);
+        questionDTO.setCateName(cate.getCateName());
+        questionDTO.setIllId(ill_id);
+        questionDTO.setIllName(ill.getIllName());
+        questionDTO.setDescription(description);
+        questionDTO.setMark(mark);
+        questionDTO.setAnswer(answer);
+        questionDTO.setContentA(content_a);
+        questionDTO.setContentB(content_b);
+        questionDTO.setContentC(content_c);
+        questionDTO.setContentD(content_d);
+        Map<String, Object> questionMap = new HashMap<>();
         questionMap.put("error_message", "success");
-        questionMap.put("qid", String.valueOf(question.getQid()));
+        questionMap.put("question", questionDTO);
         return questionMap;
     }
 

--- a/backend/src/main/java/com/example/petbackend/service/question/GetQuestionsService.java
+++ b/backend/src/main/java/com/example/petbackend/service/question/GetQuestionsService.java
@@ -3,6 +3,10 @@ package com.example.petbackend.service.question;
 import java.util.Map;
 
 public interface GetQuestionsService {
-    //带搜索值的分页查询
-    Map<String, Object> getAllQuestion(Integer page, Integer pageSize, String key);
+    //按照题目搜索分页返回题目列表
+    Map<String, Object> getAllQuestionByDescription(Integer page, Integer pageSize, String key);
+    //按照病名搜索分页返回题目列表
+    Map<String, Object> getAllQuestionByIll(Integer page, Integer pageSize, String key);
+    //按照qid返回题目详情
+    Map<String, Object> getQuestionByQid(Integer qid);
 }

--- a/backend/src/main/java/com/example/petbackend/service/question/QuestionService.java
+++ b/backend/src/main/java/com/example/petbackend/service/question/QuestionService.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public interface QuestionService {
     //添加题目
-    Map<String, String> addQuestion(Integer cate_id, Integer ill_id, String description,
+    Map<String, Object> addQuestion(Integer cate_id, Integer ill_id, String description,
                                     Integer answer, Integer mark, String content_a,
                                     String content_b, String content_c, String content_d);
     //修改题目


### PR DESCRIPTION
## 更新描述
1. 实现题目查询的三个接口
- 按照题干搜索分页获取所有题目
- 按照病名搜索分页获取题目列表
- 根据ID查看题目详情
2. 根据前端需求更改了添加题目接口，均已通过postman测试

## 类型
- [ ] Bug Fix
- [x] New Feature
- [ ] Architecture
- [x] Refactor
- [ ] Other

## 如何测试
1.
<img width="914" alt="截屏2024-04-01 下午4 00 15" src="https://github.com/yy6768/PetBackend/assets/135817370/73ba87b8-5b23-4522-a726-f144a4303b5a">
2.
<img width="905" alt="截屏2024-04-01 下午4 01 06" src="https://github.com/yy6768/PetBackend/assets/135817370/497760cf-6de1-4ec5-a9c5-ed8387da9853">
3.
<img width="914" alt="截屏2024-04-01 下午4 01 32" src="https://github.com/yy6768/PetBackend/assets/135817370/21f22744-398a-4d71-b99a-3ffbf2d5c5b0">

## Checklist

- [x] 我已经在本地测试过我的更改。
- [ ] 我已经添加了相应的测试。
- [x] 我已经更新了相应的文档。
- [x] 我遵循了代码的风格和质量指南。